### PR TITLE
fix(web): Fixed typo in root endpoint

### DIFF
--- a/common_commit/main.py
+++ b/common_commit/main.py
@@ -6,7 +6,7 @@ app = FastAPI()
 
 @app.get("/")
 def get_root():
-    return {"Hello": "world!"}
+    return {"Hello": "World!"}
 
 @app.get("/me")
 def get_user():


### PR DESCRIPTION
Changed from 'world!' to 'World!' in response